### PR TITLE
Ma level1 platforms adjustment

### DIFF
--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -201,8 +201,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2777604}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -7.25, y: -9.64, z: 0}
-  m_LocalScale: {x: 2.2183146, y: 0.79783463, z: 1}
+  m_LocalPosition: {x: -7.25, y: -15, z: 0}
+  m_LocalScale: {x: 2.5, y: 0.8, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -336,7 +336,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 38673916}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -17.2, y: 12.3, z: 0}
+  m_LocalPosition: {x: -0.4, y: 12.3, z: 0}
   m_LocalScale: {x: 0.8817555, y: 0.8772296, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -498,7 +498,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -17.2, y: 14.4, z: -10}
+  m_LocalPosition: {x: 1.6352764, y: 14.400002, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -680,7 +680,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 747113276}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 1.2, y: 1.91, z: -0.19889727}
+  m_LocalPosition: {x: 18.7, y: 1.91, z: -0.19889727}
   m_LocalScale: {x: 1.1625, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -829,8 +829,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 862884581}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 6.09, y: 0.74, z: 0}
-  m_LocalScale: {x: 3.8212302, y: 0.97380716, z: 1}
+  m_LocalPosition: {x: 26.6, y: -0.3, z: 0}
+  m_LocalScale: {x: 3.5, y: 0.8, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -914,8 +914,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1144739576}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -32.84171, y: 8.94079, z: 0}
-  m_LocalScale: {x: 2.8568528, y: 17.298426, z: 1}
+  m_LocalPosition: {x: -13, y: 9, z: 0}
+  m_LocalScale: {x: 4, y: 18, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1011,7 +1011,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1397981392}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -17.2, y: 14.4, z: -10}
+  m_LocalPosition: {x: -0.4, y: 14.4, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
@@ -1062,7 +1062,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1483957753}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 108.4, y: 11.9073, z: 0}
+  m_LocalPosition: {x: 121.3, y: 0.3, z: 0}
   m_LocalScale: {x: 1.9400747, y: 7.585459, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1185,8 +1185,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1562775939}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 129.79904, y: 11.817365, z: 0}
-  m_LocalScale: {x: 31.012312, y: 7.749943, z: 1}
+  m_LocalPosition: {x: 140, y: -4, z: 0}
+  m_LocalScale: {x: 30, y: 8, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1322,8 +1322,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1611871598}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -19.8119, y: -3.2673, z: 0}
-  m_LocalScale: {x: 28.916468, y: 7.117755, z: 1}
+  m_LocalPosition: {x: 0, y: -4, z: 0}
+  m_LocalScale: {x: 30, y: 8, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1433,8 +1433,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1642278058}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.2651, y: 2.56, z: 0}
-  m_LocalScale: {x: 4.7074003, y: 0.7979238, z: 1}
+  m_LocalPosition: {x: 20, y: 2, z: 0}
+  m_LocalScale: {x: 4, y: 0.8, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1494,8 +1494,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1727101025}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 55.8057, y: 23.7508, z: 0}
-  m_LocalScale: {x: 177.4385, y: 60.931553, z: 1}
+  m_LocalPosition: {x: 70, y: 20.6, z: 0}
+  m_LocalScale: {x: 167.79028, y: 56.20936, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
@@ -1610,8 +1610,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2139876044}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 143.3, y: 24.96, z: 0}
-  m_LocalScale: {x: 4.0103626, y: 18.535326, z: 1}
+  m_LocalPosition: {x: 153, y: 9, z: 0}
+  m_LocalScale: {x: 4, y: 18, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scripts/GroundSpawner.cs
+++ b/Assets/Scripts/GroundSpawner.cs
@@ -15,8 +15,8 @@ public class GroundSpawner : MonoBehaviour
     [SerializeField]
     float duration = 40f;
 
-    float minY = 0.5f;
-    float maxY = 2.2f;
+    float minY = -1.5f;
+    float maxY = 1.5f;
 
 
     // Start is called before the first frame update
@@ -47,32 +47,25 @@ public class GroundSpawner : MonoBehaviour
     //funkcija koja random poziva neki od 3 definirana objekta za ground i postavlja ih na random generirana mjesta u sceni
     public void SpawnGround()
     {
-        
+        //random odabir koji ground ce se stvorit
         int randomNum = Random.Range(1, 4);
+        //random odabir udaljenosti izmedu dva grounda
         int x = Random.Range(3, 5);
-        float y = Random.Range(minY, maxY);
+        //random odabir udaljensoti visina dva grounda
+        float y = Random.Range(minY,maxY);
 
-        Debug.Log(minY);
+        
         if (randomNum == 1)
         {   
-            minY=minY+1f;
-            maxY=maxY+1f;
             Instantiate(Ground1, new Vector3(transform.position.x + x, y, 0), Quaternion.identity);
-          
         }
         if (randomNum == 2)
         {
-            minY=minY+1f;
-            maxY=maxY+1f;
             Instantiate(Ground2, new Vector3(transform.position.x + x, y, 0), Quaternion.identity);
-            
         }
         if (randomNum == 3)
         {
-            minY=minY+1f;
-            maxY=maxY+1f;
             Instantiate(Ground3, new Vector3(transform.position.x + x, y, 0), Quaternion.identity);
-            
         }
        
     }

--- a/Assets/Scripts/GroundSpawner.cs
+++ b/Assets/Scripts/GroundSpawner.cs
@@ -16,7 +16,7 @@ public class GroundSpawner : MonoBehaviour
     float duration = 40f;
 
     float minY = -1.5f;
-    float maxY = 1.5f;
+    float maxY = 1.2f;
 
 
     // Start is called before the first frame update
@@ -50,7 +50,7 @@ public class GroundSpawner : MonoBehaviour
         //random odabir koji ground ce se stvorit
         int randomNum = Random.Range(1, 4);
         //random odabir udaljenosti izmedu dva grounda
-        int x = Random.Range(3, 5);
+        int x = Random.Range(4, 6);
         //random odabir udaljensoti visina dva grounda
         float y = Random.Range(minY,maxY);
 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 2021.3.21f1
-m_EditorVersionWithRevision: 2021.3.21f1 (1b156197d683)
+m_EditorVersion: 2021.3.20f1
+m_EditorVersionWithRevision: 2021.3.20f1 (577897200b8b)

--- a/UserSettings/EditorUserSettings.asset
+++ b/UserSettings/EditorUserSettings.asset
@@ -9,10 +9,10 @@ EditorUserSettings:
       value: 5406550300505b5f5f085a21412707444f154b2b742c72322c784531e1e5316e
       flags: 0
     RecentlyUsedSceneGuid-1:
-      value: 515250075c0c595e5f5a5e71122159444e4e4a2f7a7d7f602f284d66b4b76661
+      value: 535201045c54500c5f5f5f7513275b44144f1c282a7b2365782c446ab2e16c3a
       flags: 0
     RecentlyUsedSceneGuid-2:
-      value: 535201045c54500c5f5f5f7513275b44144f1c282a7b2365782c446ab2e16c3a
+      value: 515250075c0c595e5f5a5e71122159444e4e4a2f7a7d7f602f284d66b4b76661
       flags: 0
     vcSharedLogLevel:
       value: 0d5e400f0650


### PR DESCRIPTION
Ovako izgleda level prije generiranja nasumičnog terena. To su te dvije statičke platforme i stavljene su na istu visinu.
Dva terena na kraju prve platforme statička su i od njih se dalje kreira teren.
![image](https://user-images.githubusercontent.com/119117651/228810217-287d49d3-63a6-400a-a8bd-75c6f0c97a3d.png)

Ovako izgleda stvoreni teren u prvom pokušaju.

![image](https://user-images.githubusercontent.com/119117651/228810671-31594d1f-f0b4-4e26-915e-c86253e7dd07.png)

A ovako u drugom pokušaju.

![image](https://user-images.githubusercontent.com/119117651/228810942-d5e86f42-9bfc-46f7-9988-07c7343fb19b.png)

Ne postoji mogućnost manualnog postavljanja granica između udaljenosti na x i y osi između dva stvorena terena
